### PR TITLE
made python version in Pipfile less specific

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,4 @@ pylint-django = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.6"
+python_version = "3"


### PR DESCRIPTION
Since we have team members who cannot currently bump to `3.9` just putting `"3"` for the Python version seems to let everyone just use whatever they have installed -- for me that's `3.9.1`