### PR TITLE
added tag support to create post

### DIFF
--- a/rare_api/views/post.py
+++ b/rare_api/views/post.py
@@ -9,7 +9,7 @@ from rest_framework import serializers
 from rest_framework import status
 from django.contrib.auth.models import User
 from rest_framework.decorators import action
-from rare_api.models import Post, RareUser, Category, Tag, Reaction
+from rare_api.models import Post, RareUser, Category, Tag, Reaction, PostTag
 
 class PostView(ViewSet):
     
@@ -25,6 +25,10 @@ class PostView(ViewSet):
 
         try:
             post.save()
+            tags = request.data["tags"]
+            for tag in tags:
+                post.tags.add(tag["id"])
+
             serializer = PostSerializer(post, context={'request': request})
             return Response(serializer.data)
         except ValidationError as ex:


### PR DESCRIPTION
1.  Modified `views/post.py` to support adding tags to a post within the create method

STEPS TO TEST

1.  Checkout to branch mec-create-post2
2. In Postman, POST to /posts with the following example body:
    {
        "category": 2,
        "title": "example",
        "publication_date": "2021-08-18",
        "image_url": "https://picsum.photos/300",
        "content": "this is a test",
        "approved": false,
        "tags": [{"id": 1, "label": "Current Events"}]
    }
3.  New post should be created with tag included in the post body