### PR TITLE
New Custom Property on Post Class

### DIFF
--- a/rare_api/fixtures/post_reactions.json
+++ b/rare_api/fixtures/post_reactions.json
@@ -16,5 +16,14 @@
             "post": 2,
             "reaction": 1
         }
+    },
+    {
+        "model": "rare_api.postreaction",
+        "pk": 3,
+        "fields": {
+            "rare_user": 2,
+            "post": 1,
+            "reaction": 1
+        }
     }
 ]

--- a/rare_api/models/post.py
+++ b/rare_api/models/post.py
@@ -1,3 +1,5 @@
+
+from rare_api.models.reaction import Reaction
 from django.db import models
 from django.db.models.deletion import CASCADE
 
@@ -22,3 +24,14 @@ class Post(models.Model):
     @isMine.setter
     def isMine(self, value):
         self.__isMine = value
+
+    @property
+    def reaction_counter(self):
+        reactions = Reaction.objects.filter(post=self).values('id', 'label', 'image_url')
+        reaction_counter = {}
+        for reaction in reactions:
+            if reaction['id'] in reaction_counter:
+                reaction_counter[reaction['id']]['count'] += 1
+            else:
+                reaction_counter[reaction['id']] = {'count': 1, 'image_url': reaction['image_url']}
+        return reaction_counter

--- a/rare_api/views/post.py
+++ b/rare_api/views/post.py
@@ -142,4 +142,4 @@ class PostSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
         fields = ('id', 'rare_user', 'category', 'title', 'publication_date', 'image_url',
-                    'content', 'approved', 'isMine', 'tags', 'reactions')
+                    'content', 'approved', 'isMine', 'tags', 'reactions', 'reaction_counter')

--- a/rare_api/views/post.py
+++ b/rare_api/views/post.py
@@ -142,4 +142,4 @@ class PostSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
         fields = ('id', 'rare_user', 'category', 'title', 'publication_date', 'image_url',
-                    'content', 'approved', 'isMine', 'tags', 'reactions', 'reaction_counter')
+                    'content', 'approved', 'isMine', 'tags',  'reaction_counter')


### PR DESCRIPTION
## Files Changed
`/views/post.py` and `models/post.py`

## Functionality Added
When you perform a GET fetch call on the Posts db, the call should return an object with numerical keys. The name of the key refers to the id of the reaction it tracks, inside of key you will see objects with keys for "count" and "image_url" as a value.

## Testing
Pull from branch `al-testing5` and open up Postman. Perform a GET fetch call on "localhost:8000/posts" and confirm that the returned object has valid keys.