### PR TITLE
VC "Zero" Reacts on Reaction Counter property

### DIFF
--- a/rare_api/fixtures/reactions.json
+++ b/rare_api/fixtures/reactions.json
@@ -12,7 +12,7 @@
     "pk": 2,
     "fields": {
       "label": "Dislike",
-      "image_url": "https://commons.wikimedia.org/wiki/Category:Thumbs_down_icons#/media/File:Daumen_runter_90.JPG"
+      "image_url": "https://upload.wikimedia.org/wikipedia/commons/3/3c/Daumen_runter_90.JPG"
     }
   }
 ]

--- a/rare_api/fixtures/reactions.json
+++ b/rare_api/fixtures/reactions.json
@@ -1,10 +1,18 @@
 [
-    {
-        "model": "rare_api.reaction",
-        "pk": 1,
-        "fields": {
-            "label": "Like",
-            "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/23/Facebook_Like_button.svg/1024px-Facebook_Like_button.svg.png"
-        }
+  {
+    "model": "rare_api.reaction",
+    "pk": 1,
+    "fields": {
+      "label": "Like",
+      "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/23/Facebook_Like_button.svg/1024px-Facebook_Like_button.svg.png"
     }
+  },
+  {
+    "model": "rare_api.reaction",
+    "pk": 2,
+    "fields": {
+      "label": "Dislike",
+      "image_url": "https://commons.wikimedia.org/wiki/Category:Thumbs_down_icons#/media/File:Daumen_runter_90.JPG"
+    }
+  }
 ]

--- a/rare_api/models/post.py
+++ b/rare_api/models/post.py
@@ -1,4 +1,3 @@
-
 from rare_api.models.reaction import Reaction
 from django.db import models
 from django.db.models.deletion import CASCADE
@@ -27,11 +26,22 @@ class Post(models.Model):
 
     @property
     def reaction_counter(self):
-        reactions = Reaction.objects.filter(post=self).values('id', 'label', 'image_url')
+        reactions = Reaction.objects.filter(
+            post=self).values('id', 'label', 'image_url')
         reaction_counter = {}
         for reaction in reactions:
             if reaction['id'] in reaction_counter:
                 reaction_counter[reaction['id']]['count'] += 1
             else:
-                reaction_counter[reaction['id']] = {'count': 1, 'image_url': reaction['image_url']}
+                reaction_counter[reaction['id']] = {
+                    'count': 1, 'image_url': reaction['image_url'], 'label': reaction['label']}
+
+        all_reactions = Reaction.objects.all().values('id', 'label', 'image_url')
+        print(all_reactions)
+        for reaction in all_reactions:
+            if reaction['id'] in reaction_counter:
+                pass
+            else:
+                reaction_counter[reaction['id']] = {
+                    'count': 0, 'image_url': reaction['image_url'], 'label': reaction['label']}
         return reaction_counter


### PR DESCRIPTION
- added a new "dislike" reaction to `rare_api/fixtures/reactions.json`
- addded to the reaction_counter property in `rare_api/models/post.py` so that even if there is no PostReaction for a given reaction it will still be included as a 0 in the counter

To Test:
- rebuild your database
- GET post 1 and look at the like/dislike reaction counts